### PR TITLE
Add `no_std` compatibility

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -95,7 +95,7 @@ jobs:
         with:
           profile: minimal
           toolchain: stable
-          target: thumbv6m-none-eabi
+          target: aarch64-unknown-none
           override: true
 
       - name: Rust Cache

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -105,9 +105,9 @@ jobs:
         uses: actions-rs/cargo@v1.0.3
         with:
           command: check
-          # The thumbv6m-none-eabi doesn't support `std`, so this
+          # The aarch64-unknown-none doesn't support `std`, so this
           # will fail if the crate is not no_std compatible.
-          args: --no-default-features --target thumbv6m-none-eabi --features scale-info,serde
+          args: --no-default-features --target aarch64-unknown-none --features scale-info,serde
 
 
   fmt:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -83,6 +83,32 @@ jobs:
           # we run tests using BitVec<u64,_> which doesn't.
           args: --all-features --target wasm32-unknown-unknown
 
+  no_std:
+    name: Check no_std build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v2
+
+      - name: Install Rust stable toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          target: thumbv6m-none-eabi
+          override: true
+
+      - name: Rust Cache
+        uses: Swatinem/rust-cache@v1.3.0
+
+      - name: Check no_std build
+        uses: actions-rs/cargo@v1.0.3
+        with:
+          command: check
+          # The thumbv6m-none-eabi doesn't support `std`, so this
+          # will fail if the crate is not no_std compatible.
+          args: --no-default-features --target thumbv6m-none-eabi --features scale-info,serde
+
 
   fmt:
     name: Cargo fmt

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,12 +28,12 @@ serde = ["dep:serde"]
 scale-info = ["dep:scale-info"]
 
 [dependencies]
-scale-info = { version = "2.2.0", default-features = false, optional = true }
+scale-info = { version = "2.7.0", default-features = false, optional = true }
 codec = { package = "parity-scale-codec", version = "3.2.0", default-features = false }
 serde = { version = "1", optional = true, default-features = false, features = ["alloc"] }
 
 [dev-dependencies]
-scale-info = { version = "2.2.0", default-features = false, features = ["std", "bit-vec"] }
+scale-info = { version = "2.7.0", default-features = false, features = ["std", "bit-vec"] }
 codec = { package = "parity-scale-codec", version = "3.2.0", default-features = false, features = ["bit-vec"] }
 bitvec = "1"
 serde_json = "1.0.85"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,11 @@ keywords = ["parity", "scale", "encoding", "decoding", "bits"]
 include = ["Cargo.toml", "src/**/*.rs", "README.md", "LICENSE"]
 
 [features]
-default = ["serde", "scale-info"]
+default = ["std", "serde", "scale-info"]
+std = [
+    "scale-info/std",
+    "serde/std",
+]
 
 # Allow Bits to be serialized and deserialized from boolean arrays.
 serde = ["dep:serde"]
@@ -24,9 +28,9 @@ serde = ["dep:serde"]
 scale-info = ["dep:scale-info"]
 
 [dependencies]
-scale-info = { version = "2.2.0", default-features = false, features = ["std"], optional = true }
-codec = { package = "parity-scale-codec", version = "3.2.0", default-features = false, features = [] }
-serde = { version = "1", optional = true }
+scale-info = { version = "2.2.0", default-features = false, optional = true }
+codec = { package = "parity-scale-codec", version = "3.2.0", default-features = false }
+serde = { version = "1", optional = true, default-features = false, features = ["alloc"] }
 
 [dev-dependencies]
 scale-info = { version = "2.2.0", default-features = false, features = ["std", "bit-vec"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ include = ["Cargo.toml", "src/**/*.rs", "README.md", "LICENSE"]
 default = ["std", "serde", "scale-info"]
 std = [
     "scale-info/std",
-    "serde/std",
+    "serde?/std",
 ]
 
 # Allow Bits to be serialized and deserialized from boolean arrays.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ include = ["Cargo.toml", "src/**/*.rs", "README.md", "LICENSE"]
 [features]
 default = ["std", "serde", "scale-info"]
 std = [
-    "scale-info/std",
+    "scale-info?/std",
     "serde?/std",
 ]
 

--- a/src/bits/bits.rs
+++ b/src/bits/bits.rs
@@ -15,6 +15,7 @@
 
 #![allow(clippy::module_inception)]
 
+use alloc::vec::Vec;
 use codec::{Compact, Decode, Encode};
 
 /// This macro makes it trivial to construct [`Bits`] from either 0 and 1 bit
@@ -353,7 +354,7 @@ impl Bits {
 	}
 }
 
-impl std::iter::IntoIterator for Bits {
+impl core::iter::IntoIterator for Bits {
 	type Item = bool;
 	type IntoIter = BitsIntoIter;
 
@@ -407,7 +408,7 @@ impl<'a> Iterator for BitsIter<'a> {
 }
 impl<'a> ExactSizeIterator for BitsIter<'a> {}
 
-impl std::iter::FromIterator<bool> for Bits {
+impl core::iter::FromIterator<bool> for Bits {
 	fn from_iter<T: IntoIterator<Item = bool>>(iter: T) -> Self {
 		let iter = iter.into_iter();
 

--- a/src/bits/serde.rs
+++ b/src/bits/serde.rs
@@ -43,7 +43,7 @@ impl<'de> Deserialize<'de> for Bits {
 		impl<'de> Visitor<'de> for BitsVisitor {
 			type Value = Bits;
 
-			fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+			fn expecting(&self, formatter: &mut core::fmt::Formatter) -> core::fmt::Result {
 				formatter.write_str("a sequence of booleans")
 			}
 

--- a/src/bits/serde.rs
+++ b/src/bits/serde.rs
@@ -67,6 +67,7 @@ impl<'de> Deserialize<'de> for Bits {
 #[cfg(test)]
 mod test {
 	use crate::bits::Bits;
+	use alloc::vec;
 
 	#[test]
 	fn ser_deser_bits() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,6 +30,7 @@
 //! sequences directly into the [`Bits`] type), but don't need to be used together.
 
 #![deny(missing_docs)]
+#![cfg_attr(not(feature = "std"), no_std)]
 
 pub mod bits;
 pub mod scale;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,6 +32,8 @@
 #![deny(missing_docs)]
 #![cfg_attr(not(feature = "std"), no_std)]
 
+extern crate alloc;
+
 pub mod bits;
 pub mod scale;
 

--- a/src/scale/decode_iter.rs
+++ b/src/scale/decode_iter.rs
@@ -166,6 +166,8 @@ decode_iter!(msb, DecodeMsb0U64, u64);
 #[cfg(test)]
 mod test {
 	use super::*;
+	use alloc::vec;
+	use alloc::vec::Vec;
 	use bitvec::{
 		order::{Lsb0, Msb0},
 		vec::BitVec,

--- a/src/scale/decode_iter.rs
+++ b/src/scale/decode_iter.rs
@@ -19,7 +19,7 @@
 use codec::{Compact, Decode, Encode, Error as CodecError};
 
 fn bits_in<T>() -> u8 {
-	(std::mem::size_of::<T>() * 8) as u8
+	(core::mem::size_of::<T>() * 8) as u8
 }
 
 macro_rules! starting_bit {
@@ -82,7 +82,7 @@ macro_rules! decode_iter {
 			pub fn encoded_size(&self) -> usize {
 				let num_bits = self.len as usize;
 
-				let bytes_per_store = std::mem::size_of::<$ty>();
+				let bytes_per_store = core::mem::size_of::<$ty>();
 				let bits_per_store = bytes_per_store * 8;
 
 				// Dividing rounds down, and then multiply by number of bytes.

--- a/src/scale/encode_iter.rs
+++ b/src/scale/encode_iter.rs
@@ -96,6 +96,7 @@ encode_iter_msb!(encode_iter_msb0_u64, u64);
 #[cfg(test)]
 mod test {
 	use super::*;
+	use alloc::vec;
 	use bitvec::{
 		order::{Lsb0, Msb0},
 		vec::BitVec,

--- a/src/scale/encode_iter.rs
+++ b/src/scale/encode_iter.rs
@@ -16,10 +16,11 @@
 // This module contains functions which take an iterator of bools with known
 // sizes and encodes them to bitvecs of different shapes.
 
+use alloc::vec::Vec;
 use codec::{Compact, Encode};
 
 fn bits_in<T>() -> usize {
-	std::mem::size_of::<T>() * 8
+	core::mem::size_of::<T>() * 8
 }
 
 macro_rules! encode_iter_lsb {

--- a/src/scale/format.rs
+++ b/src/scale/format.rs
@@ -172,7 +172,7 @@ mod test {
 		let (id, types) = make_type::<T>();
 
 		// Pull out said type info:
-		let ty = match types.resolve(id).unwrap().type_def {
+		let ty = match &types.resolve(id).unwrap().type_def {
 			scale_info::TypeDef::BitSequence(b) => b,
 			_ => panic!("expected type to look like a bit sequence"),
 		};

--- a/src/scale/format.rs
+++ b/src/scale/format.rs
@@ -72,7 +72,9 @@ impl Format {
 			TypeDef::Primitive(TypeDefPrimitive::U64) => Some(StoreFormat::U64),
 			_ => None,
 		}
-		.ok_or_else(|| FromMetadataError::StoreFormatNotSupported(format!("{bit_store_def:?}")))?;
+		.ok_or_else(|| {
+			FromMetadataError::StoreFormatNotSupported(alloc::format!("{bit_store_def:?}"))
+		})?;
 
 		let bit_order_out = match &*bit_order_def {
 			"Lsb0" => Some(OrderFormat::Lsb0),

--- a/src/scale/format.rs
+++ b/src/scale/format.rs
@@ -17,6 +17,7 @@
 //! [`OrderFormat`] and describes the different possible wire formats of a bit sequence.
 
 use alloc::string::String;
+
 /// A description of the format used to SCALE encode some bits.
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
 pub struct Format {

--- a/src/scale/format.rs
+++ b/src/scale/format.rs
@@ -17,6 +17,8 @@
 //! [`OrderFormat`] and describes the different possible wire formats of a bit sequence.
 
 use alloc::string::String;
+#[cfg(feature = "scale-info")]
+use alloc::string::ToString;
 
 /// A description of the format used to SCALE encode some bits.
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
@@ -82,7 +84,7 @@ impl Format {
 			"Msb0" => Some(OrderFormat::Msb0),
 			_ => None,
 		}
-		.ok_or(FromMetadataError::OrderFormatNotSupported(bit_order_def))?;
+		.ok_or(FromMetadataError::OrderFormatNotSupported(bit_order_def.to_string()))?;
 
 		Ok(Format { store: bit_store_out, order: bit_order_out })
 	}

--- a/src/scale/format.rs
+++ b/src/scale/format.rs
@@ -46,20 +46,20 @@ impl Format {
 		ty: &scale_info::TypeDefBitSequence<scale_info::form::PortableForm>,
 		types: &scale_info::PortableRegistry,
 	) -> Result<Format, FromMetadataError> {
-		let bit_store_ty = ty.bit_store_type().id();
-		let bit_order_ty = ty.bit_order_type().id();
+		let bit_store_ty = ty.bit_store_type.id;
+		let bit_order_ty = ty.bit_order_type.id;
 
 		// What is the backing store type expected?
-		let bit_store_def = types
+		let bit_store_def = &types
 			.resolve(bit_store_ty)
 			.ok_or(FromMetadataError::StoreFormatNotFound(bit_store_ty))?
-			.type_def();
+			.type_def;
 
 		// What is the bit order type expected?
 		let bit_order_def = types
 			.resolve(bit_order_ty)
 			.ok_or(FromMetadataError::OrderFormatNotFound(bit_order_ty))?
-			.path()
+			.path
 			.ident()
 			.ok_or(FromMetadataError::NoBitOrderIdent)?;
 
@@ -164,7 +164,7 @@ mod test {
 		let id = types.register_type(&m);
 		let portable_registry: scale_info::PortableRegistry = types.into();
 
-		(id.id(), portable_registry)
+		(id.id, portable_registry)
 	}
 
 	fn assert_format<T: scale_info::TypeInfo + 'static>(store: StoreFormat, order: OrderFormat) {
@@ -172,7 +172,7 @@ mod test {
 		let (id, types) = make_type::<T>();
 
 		// Pull out said type info:
-		let ty = match types.resolve(id).unwrap().type_def() {
+		let ty = match types.resolve(id).unwrap().type_def {
 			scale_info::TypeDef::BitSequence(b) => b,
 			_ => panic!("expected type to look like a bit sequence"),
 		};

--- a/src/scale/format.rs
+++ b/src/scale/format.rs
@@ -16,6 +16,7 @@
 //! Ths module defines a [`Format`], which is basically a [`StoreFormat`] and an
 //! [`OrderFormat`] and describes the different possible wire formats of a bit sequence.
 
+use alloc::string::String;
 /// A description of the format used to SCALE encode some bits.
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
 pub struct Format {
@@ -130,8 +131,8 @@ pub enum FromMetadataError {
 	OrderFormatNotSupported(String),
 }
 
-impl std::fmt::Display for FromMetadataError {
-	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Display for FromMetadataError {
+	fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
 		match self {
 			FromMetadataError::OrderFormatNotFound(n) => {
 				write!(f, "Bit order type {n} not found in registry")
@@ -151,6 +152,8 @@ impl std::fmt::Display for FromMetadataError {
 		}
 	}
 }
+
+#[cfg(feature = "std")]
 impl std::error::Error for FromMetadataError {}
 
 #[cfg(feature = "scale-info")]

--- a/src/scale/mod.rs
+++ b/src/scale/mod.rs
@@ -9,6 +9,7 @@
 
 mod decode_iter;
 mod encode_iter;
+use alloc::vec::Vec;
 use codec::Error as CodecError;
 
 pub mod format;

--- a/src/scale/mod.rs
+++ b/src/scale/mod.rs
@@ -242,6 +242,7 @@ impl<'a> Decoder<'a> {
 mod test {
 	use super::format::{Format, OrderFormat, StoreFormat};
 	use super::*;
+	use alloc::vec;
 	use bitvec::{
 		order::{BitOrder, Lsb0, Msb0},
 		store::BitStore,


### PR DESCRIPTION
- Adds `no_std` compatibility  by adding a `std` feature and changing stds-import to `core` or `alloc`. 
- Updates `scale-info` from v2.2 to v 2.7
- Fixes some clippy deprecated warnings.